### PR TITLE
feat: handle entities that don't have a relationships property

### DIFF
--- a/tap_krow/client.py
+++ b/tap_krow/client.py
@@ -182,8 +182,9 @@ class KrowStream(RESTStream):
             d = {
                 "id": record["id"],
                 **record["attributes"],
-                **record["relationships"],
             }
+            if 'relationships' in record:
+                d.update(record["relationships"])
             d = make_fields_meltano_select_compatible(d)
 
             # remove extraneous keys that only muddle the field names in the output

--- a/tap_krow/tests/api_responses/campaigns/campaigns_no_relationships_property.json
+++ b/tap_krow/tests/api_responses/campaigns/campaigns_no_relationships_property.json
@@ -1,0 +1,43 @@
+{
+    "data": [
+        {
+            "id": "9b2f9b64-ddb5-477b-ac24-4cf015df8c2d",
+            "type": "campaigns",
+            "attributes": {
+                "utm_source": "Advertising_Indeed_Sponsored",
+                "utm_medium": "PPC",
+                "utm_campaign": "Walmart",
+                "utm_term": null,
+                "utm_content": "Supply_Chain_and_Logistics",
+                "created_at": "2023-04-26T20:37:38.758Z",
+                "updated_at": "2023-04-26T20:40:00.866Z"
+            }
+        },
+        {
+            "id": "8ce08833-f338-4d2b-8d0c-c39f91f3bcda",
+            "type": "campaigns",
+            "attributes": {
+                "utm_source": null,
+                "utm_medium": null,
+                "utm_campaign": null,
+                "utm_term": null,
+                "utm_content": null,
+                "created_at": "2023-04-26T20:08:43.093Z",
+                "updated_at": "2023-04-26T20:10:40.229Z"
+            }
+        }
+    ],
+    "meta": {
+        "pagination": {
+            "total": 2,
+            "pages": 1
+        }
+    },
+    "links": {
+        "self": "/v1/organizations/e00af7dd-a8bb-4666-ae1a-0ed0e4e922a6/campaigns?page%5Bnumber%5D=1&page%5Bsize%5D=25",
+        "next": null,
+        "prev": null,
+        "first": "/v1/organizations/e00af7dd-a8bb-4666-ae1a-0ed0e4e922a6/campaigns?page%5Bnumber%5D=1&page%5Bsize%5D=25",
+        "last": "/v1/organizations/e00af7dd-a8bb-4666-ae1a-0ed0e4e922a6/campaigns?page%5Bnumber%5D=1&page%5Bsize%5D=25"
+    }
+}

--- a/tap_krow/tests/test_client.py
+++ b/tap_krow/tests/test_client.py
@@ -5,7 +5,7 @@ import pytest
 import pytz
 from urllib.parse import urlparse
 
-from tap_krow.streams import OrganizationsStream
+from tap_krow.streams import CampaignStream, OrganizationsStream
 
 
 @pytest.fixture(scope="module")
@@ -67,3 +67,10 @@ def test_parse_response_does_not_return_records_earlier_than_the_stop_point(resp
 
 
 # endregion
+
+def test_handles_when_entities_do_not_have_a_relationships_property(api_responses, stream_factory):
+    stream = stream_factory(CampaignStream)
+    # test with a file that contains campaign entities without a "relationship" property
+    res = stream.parse_response(api_responses["campaigns"]["campaigns_no_relationships_property.json"])
+    # the simple fact that no exception was thrown indicates that this test succeeded
+    assert next(res)['id'] == '9b2f9b64-ddb5-477b-ac24-4cf015df8c2d'


### PR DESCRIPTION
[from slack message](https://datateer.slack.com/archives/C029ZF0QJ1Z/p1682529625948509)

## 📑 Description
The API is now returning results from the campaign endpoint that do not have a "relationship" property. The code assumed it would be there. This update handles the situation where it is missing. 

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
