### PR TITLE
Sr 3598 override applicant url with v2

### DIFF
--- a/tap_krow/streams.py
+++ b/tap_krow/streams.py
@@ -165,6 +165,7 @@ class LocationsStream(KrowStream):
 class ApplicantsStream(KrowStream):
     name = "applicants"
     path = "/organizations/{organization_id}/applicants"
+    url_base = "https://api.next.krow.ai/v2"
     schema = PropertiesList(
         Property("id", StringType, required=True),
         Property("action", StringType),


### PR DESCRIPTION
[sr-3598](https://support.datateer.com/a/tickets/3598)

## 📑 Description
KROW engineering created a new version of the applicants endpoint. It uses elasticsearch in their backend and is much faster.

this change overrides the v1 URL to apply the v2 URL. Unfortunately the entire API is not versioned, just the applicants endpoint. So this is a little less intuitive and less configurable than before. But much faster

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
