### PR TITLE
Applicant stream issues

### DIFF
--- a/tap_krow/client.py
+++ b/tap_krow/client.py
@@ -203,6 +203,14 @@ class KrowStream(RESTStream):
                 )
                 return
             yield d
+    
+    def backoff_max_tries(self) -> int:
+        """The number of attempts before giving up when retrying requests.
+
+        Returns:
+            Number of max retries.
+        """
+        return 20
 
 
 class CustomerNotEnabledError(Exception):

--- a/tap_krow/client.py
+++ b/tap_krow/client.py
@@ -1,22 +1,23 @@
 """REST client handling, including krowStream base class."""
 
-from datetime import datetime
-import dateutil
 import logging
+from datetime import datetime
+from typing import Any, Dict, Iterable, Optional
 from urllib.parse import parse_qsl
-import requests
-from typing import Any, Dict, Optional, Iterable
 
-from singer_sdk.helpers.jsonpath import extract_jsonpath
-from singer_sdk.streams import RESTStream
+import dateutil
+import requests
 from singer_sdk.exceptions import FatalAPIError, RetriableAPIError
+from singer_sdk.helpers.jsonpath import extract_jsonpath
+from singer_sdk.pagination import BaseAPIPaginator, BaseHATEOASPaginator
+from singer_sdk.streams import RESTStream
+
 from tap_krow.auth import krowAuthenticator
 from tap_krow.normalize import (
     flatten_dict,
-    remove_unnecessary_keys,
     make_fields_meltano_select_compatible,
+    remove_unnecessary_keys,
 )
-from singer_sdk.pagination import BaseHATEOASPaginator, BaseAPIPaginator
 
 REPLICATION_KEY = "updated_at"
 
@@ -73,6 +74,7 @@ class KrowStream(RESTStream):
     """KROW stream class."""
 
     page_size = 100  # this is the upper limit allowed by the KROW API
+    _LOG_REQUEST_METRIC_URLS: bool = True  # Metrics include context for debugging
 
     @property
     def url_base(self) -> str:
@@ -216,4 +218,5 @@ class KrowStream(RESTStream):
 class CustomerNotEnabledError(Exception):
     """
     Some organizations do not have interviewing enabled.
+    """
     """

--- a/tap_krow/client.py
+++ b/tap_krow/client.py
@@ -219,4 +219,3 @@ class CustomerNotEnabledError(Exception):
     """
     Some organizations do not have interviewing enabled.
     """
-    """

--- a/tap_krow/streams.py
+++ b/tap_krow/streams.py
@@ -165,7 +165,6 @@ class LocationsStream(KrowStream):
 class ApplicantsStream(KrowStream):
     name = "applicants"
     path = "/organizations/{organization_id}/applicants"
-    url_base = "https://api.next.krow.ai/v2"
     schema = PropertiesList(
         Property("id", StringType, required=True),
         Property("action", StringType),


### PR DESCRIPTION
1. v2 endpoint was breaking Applicant stream, swapping back (As Krow fixed the underlying issue on their end) Note that if the request's get close to ~30 seconds Krow's Heroku instance will time out on us and we need to get those requests below 30 seconds
2. Extend number of retries to give us a better chance when getting 500's
3. Give us more information in the metric logs to help with debugging